### PR TITLE
make shell.py __main__.py so the file can be run without cd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+__pychache__

--- a/__main__.py
+++ b/__main__.py
@@ -1,6 +1,4 @@
 import shin
-import time
-import sys
 from colorama import Fore, Style
 
 print("Shin Lang v0.2 | Author: Shinero")
@@ -22,4 +20,3 @@ while True:
 
         else:
             print(repr(result))
-


### PR DESCRIPTION
Right now, to use the language an user has to do
```bash
git clone https://github.com/Sarthak2143/shin
cd shin/
python3 shell.py
```
If we make `shell.py` `__main__.py`, that will be
```bash
git clone https://github.com/Sarthak2143/shin
python3 shin
```
.
Also I removed unused imports in `__main__.py`